### PR TITLE
README correct link dmenu-manjaro

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@ Categorized desktop application menu
 morc_menu is a bash script that simulates the functionality of an [Openbox](https://en.wikipedia.org/wiki/Openbox)
 / [Fluxbox](https://en.wikipedia.org/wiki/Fluxbox) style menu without requiring those window
 managers or associated dependencies. It was originally
-written for the [i3 window manager](https://en.wikipedia.org/wiki/I3_%28window_manager%29), and using '[dmenu-manjaro](https://github.com/oberon2007/dmenu-manjaro)' (wikipedia: [dmenu](https://en.wikipedia.org/wiki/Dwm#dmenu) ) as
+written for the [i3 window manager](https://en.wikipedia.org/wiki/I3_%28window_manager%29), and using '[dmenu-manjaro](https://github.com/manjaro/packages-community/tree/master/dmenu-manjaro)' (wikipedia: [dmenu](https://en.wikipedia.org/wiki/Dwm#dmenu) )
 as its front-end, but it should also work in pretty much
 any X11 environment, and has been tested with
-alternative front-ends such as the [normal/vanilla/real version of 'dmenu](http://tools.suckless.org/dmenu/)', as well as  '[rofi](https://davedavenport.github.io/rofi/)', '[zenity](https://en.wikipedia.org/wiki/Zenity)' and
+alternative front-ends such as the [normal/vanilla/real version of '[dmenu](http://tools.suckless.org/dmenu/)', as well as  '[rofi](https://davedavenport.github.io/rofi/)', '[zenity](https://en.wikipedia.org/wiki/Zenity)' and
 'yada'.
 
 morc_menu generates menus based upon the presence of


### PR DESCRIPTION
Repos oberon2007/dmenu-manjaro and dmeneu-manjaro in manjaro/packages-community where in fact identical but not officially forks. I just deleted the duplicate at my github and corrected the link accordingly...
Thanks a lot for this, @Boruch-Baum ! :smile: 
